### PR TITLE
removed all trivial unsafe

### DIFF
--- a/sonata-codec-flac/src/validate.rs
+++ b/sonata-codec-flac/src/validate.rs
@@ -81,6 +81,7 @@ impl Md5AudioValidator {
 fn slice_as_i24<'a>(hash_buf: &'a mut [u8], buf: &AudioBuffer<i32>, n_channels: usize, n_frames: usize) -> &'a [u8]{
     let frame_stride = 3 * n_channels;
 
+    //TODO: explain why this is safe
     unsafe {
         for ch in 0..n_channels {
             let mut ptr = hash_buf.as_mut_ptr().add(3 * ch);
@@ -98,6 +99,7 @@ fn slice_as_i24<'a>(hash_buf: &'a mut [u8], buf: &AudioBuffer<i32>, n_channels: 
 macro_rules! slice_as {
     ($name:ident, $type:ty) => {
         fn $name<'a>(hash_buf: &'a mut [u8], buf: &AudioBuffer<i32>, n_channels: usize, n_frames: usize) -> &'a [u8] {
+            //TODO: explain why this is safe
             unsafe {
                 let hash_slice = slice::from_raw_parts_mut(hash_buf.as_mut_ptr() as *mut $type, n_frames * n_channels);
                 

--- a/sonata-core/Cargo.toml
+++ b/sonata-core/Cargo.toml
@@ -13,3 +13,4 @@ edition = "2018"
 [dependencies]
 bitflags = "1.0.4"
 lazy_static = "1.3.0"
+byteorder = "1.3.2"

--- a/sonata-core/src/audio.rs
+++ b/sonata-core/src/audio.rs
@@ -558,6 +558,7 @@ impl<S: Sample> Signal<S> for AudioBuffer<S> {
         assert!(second_idx <self.buf.len());
 
         //FIXME:  this is instant UB, just call chan_pair_mut(0,0) and you get mutable aliasses
+        //maybe try Slice::split_at_mut()
         unsafe {
             let ptr = self.buf.as_mut_ptr();
             (slice::from_raw_parts_mut(ptr.add(first_idx), self.n_frames),

--- a/sonata-core/src/audio.rs
+++ b/sonata-core/src/audio.rs
@@ -308,9 +308,9 @@ impl<S : Sample> AudioBuffer<S> {
         // Practically speaking, it is not possible to allocate more than usize samples.
         debug_assert!(n_sample_capacity <= usize::max_value() as u64);
 
-        // Allocate memory for the sample data, but do not zero the memory.
-        let mut buf = Vec::with_capacity(n_sample_capacity as usize);
-        unsafe { buf.set_len(n_sample_capacity as usize) };
+        // Allocate memory for the sample data, but zero initialize it cause uninitialized memory
+        // is ub pretty much automatically
+        let mut buf = vec![S::default(); n_sample_capacity as usize];
 
         AudioBuffer {
             buf,
@@ -354,6 +354,7 @@ impl<S : Sample> AudioBuffer<S> {
     /// `chan()` to selectively choose the plane to read.
     pub fn planes<'a>(&'a self) -> AudioPlanes<'a, S> {
         let mut planes = AudioPlanes {
+            // FIXME: this is UB
             planes: unsafe { std::mem::uninitialized() },
             n_planes: self.spec.channels.len(),
         };
@@ -374,6 +375,7 @@ impl<S : Sample> AudioBuffer<S> {
     /// `render()`, `fill()`, `chan_mut()`, and `chan_pair_mut()` to mutate the buffer.
     pub fn planes_mut<'a>(&'a mut self) -> AudioPlanesMut<'a, S> {
         let mut planes = AudioPlanesMut {
+            // FIXME: this is UB
             planes: unsafe { std::mem::uninitialized() },
             n_planes: self.spec.channels.len(),
         };
@@ -383,6 +385,7 @@ impl<S : Sample> AudioBuffer<S> {
 
             // Only fill the planes array up to the number of channels.
             for i in 0..planes.n_planes {
+                // FIXME: UB, indexing into uninitialized memory
                 planes.planes[i] = slice::from_raw_parts_mut(ptr as *mut S, self.n_frames);
                 ptr = ptr.add(self.n_capacity);
             }
@@ -554,6 +557,7 @@ impl<S: Sample> Signal<S> for AudioBuffer<S> {
         assert!(first_idx < self.buf.len());
         assert!(second_idx <self.buf.len());
 
+        //FIXME:  this is instant UB, just call chan_pair_mut(0,0) and you get mutable aliasses
         unsafe {
             let ptr = self.buf.as_mut_ptr();
             (slice::from_raw_parts_mut(ptr.add(first_idx), self.n_frames),
@@ -588,6 +592,7 @@ impl<S: Sample> Signal<S> for AudioBuffer<S> {
 
             // Only fill the planes array up to the number of channels.
             for i in 0..planes.n_planes {
+                //FIXME: this is instant UB, you are indexing into uninitialized memory
                 planes.planes[i] = slice::from_raw_parts_mut(ptr as *mut S, n_render_frames);
                 ptr = ptr.add(self.n_capacity);
             }
@@ -607,6 +612,7 @@ impl<S: Sample> Signal<S> for AudioBuffer<S> {
         F: Fn(S) -> S
     {
         debug_assert!(self.n_frames <= self.n_capacity);
+        //TODO: document why this is actually safe
 
         unsafe {
             let mut plane_start = self.buf.as_mut_ptr();
@@ -796,9 +802,10 @@ impl<S: Sample + WriteSample> SampleBuffer<S> {
                 let stride = src.n_capacity;
 
                 for i in 0..n_frames {
+                    //TODO: possibly replace by Slice::chunks() and Iterator::step_by()
                     for ch in 0..n_channels {
-                        let sample = unsafe { src.buf.get_unchecked(ch * stride + i) };
-                        S::write((*sample).into_sample(), &mut writer);
+                        let sample = src.buf[ch * stride + i];
+                        S::write((sample).into_sample(), &mut writer);
                     }
                 }
             },
@@ -843,8 +850,9 @@ impl<S: Sample + WriteSample> SampleBuffer<S> {
                 let stride = src.n_capacity;
 
                 for i in 0..n_frames {
+                    //TODO: possibly replace by Slice::chunks() and Iterator::step_by()
                     for ch in 0..n_channels {
-                        unsafe { S::write(*src.buf.get_unchecked(ch * stride + i), &mut writer); }
+                        S::write(src.buf[ch * stride + i], &mut writer);
                     }
                 }
             },
@@ -884,6 +892,7 @@ impl<'a, S: Sample + WriteSample> SampleWriter<'a, S> {
 
     fn from_buf(n_samples: usize, buf: &mut SampleBuffer<S>) -> SampleWriter<S> {
         let bytes = buf.req_bytes_mut(n_samples);
+        //TODO: explain why this is safe
         unsafe {
             SampleWriter {
                 buf: slice::from_raw_parts_mut(
@@ -895,7 +904,7 @@ impl<'a, S: Sample + WriteSample> SampleWriter<'a, S> {
 
     pub fn write(&mut self, src: S::StreamType) {
         // Copy the source sample to the output buffer at the next writeable index.
-        unsafe { *self.buf.get_unchecked_mut(self.next) = src; }
+        self.buf[self.next] = src;
         // Increment writeable index.
         self.next += 1;
     }

--- a/sonata-core/src/io/buf_stream.rs
+++ b/sonata-core/src/io/buf_stream.rs
@@ -93,7 +93,7 @@ impl<'a> Bytestream for BufStream<'a> {
             return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "would exceed buffer"));
         }
 
-        let mut double_bytes: [u8; 2] = unsafe { std::mem::uninitialized() };
+        let mut double_bytes: [u8; 2] = [0u8; 2];
         double_bytes.copy_from_slice(&self.buf[self.pos..self.pos + 2]);
         self.pos += 2;
 
@@ -106,7 +106,7 @@ impl<'a> Bytestream for BufStream<'a> {
             return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "would exceed buffer"));
         }
 
-        let mut triple_bytes: [u8; 3] = unsafe { std::mem::uninitialized() };
+        let mut triple_bytes: [u8; 3] = [0u8; 3];
         triple_bytes.copy_from_slice(&self.buf[self.pos..self.pos + 3]);
         self.pos += 3;
 
@@ -119,7 +119,7 @@ impl<'a> Bytestream for BufStream<'a> {
             return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "would exceed buffer"));
         }
 
-        let mut quad_bytes: [u8; 4] = unsafe { std::mem::uninitialized() };
+        let mut quad_bytes: [u8; 4] = [0u8; 4];
         quad_bytes.copy_from_slice(&self.buf[self.pos..self.pos + 4]);
         self.pos += 4;
 

--- a/sonata-core/src/io/media_source_stream.rs
+++ b/sonata-core/src/io/media_source_stream.rs
@@ -294,7 +294,7 @@ impl Bytestream for MediaSourceStream {
         // If the buffer has two bytes available, copy directly from it and skip any safety or
         // buffering checks.
         if self.pos + 2 < self.end_pos {
-            double_byte.clone_from_slice(&self.buf[self.pos..self.pos + 1]);
+            double_byte.clone_from_slice(&self.buf[self.pos..self.pos + 2]);
             self.pos += 2;
         }
         // If the by buffer does not have two bytes available, copy one byte at a time from the

--- a/sonata-core/src/io/media_source_stream.rs
+++ b/sonata-core/src/io/media_source_stream.rs
@@ -281,7 +281,7 @@ impl Bytestream for MediaSourceStream {
             self.fetch_buffer_or_eof()?;
         }
 
-        let byte = unsafe { *self.buf.get_unchecked(self.pos) };
+        let byte = self.buf[self.pos];
         self.pos += 1;
 
         Ok(byte)
@@ -289,15 +289,12 @@ impl Bytestream for MediaSourceStream {
 
     // Reads two bytes from the stream and returns them in read-order or an error.
     fn read_double_bytes(&mut self) -> io::Result<[u8; 2]> {
-        let mut double_byte: [u8; 2] = unsafe { std::mem::uninitialized() };
+        let mut double_byte: [u8; 2] = [0u8; 2];
 
         // If the buffer has two bytes available, copy directly from it and skip any safety or
         // buffering checks.
         if self.pos + 2 < self.end_pos {
-            unsafe { 
-                double_byte[0] = *self.buf.get_unchecked(self.pos + 0);
-                double_byte[1] = *self.buf.get_unchecked(self.pos + 1);
-            }
+            double_byte.clone_from_slice(&self.buf[self.pos..self.pos + 1]);
             self.pos += 2;
         }
         // If the by buffer does not have two bytes available, copy one byte at a time from the
@@ -307,7 +304,7 @@ impl Bytestream for MediaSourceStream {
                 if self.pos >= self.end_pos {
                     self.fetch_buffer_or_eof()?;
                 }
-                unsafe { *double_byte.get_unchecked_mut(i) = *self.buf.get_unchecked(self.pos) }
+                double_byte[i] = self.buf[self.pos];
                 self.pos += 1;
             }
         }
@@ -317,7 +314,7 @@ impl Bytestream for MediaSourceStream {
 
     // Reads three bytes from the stream and returns them in read-order or an error.
     fn read_triple_bytes(&mut self) -> io::Result<[u8; 3]> {
-        let mut triple_byte: [u8; 3] = unsafe { std::mem::uninitialized() };
+        let mut triple_byte: [u8; 3] = [0u8; 3];
 
         // If the buffer has three bytes available, copy directly from it and skip any safety or
         // buffering checks.
@@ -332,7 +329,7 @@ impl Bytestream for MediaSourceStream {
                 if self.pos >= self.end_pos {
                     self.fetch_buffer_or_eof()?;
                 }
-                unsafe { *triple_byte.get_unchecked_mut(i) = *self.buf.get_unchecked(self.pos) }
+                triple_byte[i] = self.buf[self.pos];
                 self.pos += 1;
             }
         }
@@ -342,7 +339,7 @@ impl Bytestream for MediaSourceStream {
 
     // Reads four bytes from the stream and returns them in read-order or an error.
     fn read_quad_bytes(&mut self) -> io::Result<[u8; 4]> {
-        let mut quad_byte: [u8; 4] = unsafe { std::mem::uninitialized() };
+        let mut quad_byte: [u8; 4] = [0u8; 4];
 
         // If the buffer has four bytes available, copy directly from it and skip any safety or
         // buffering checks.
@@ -357,7 +354,7 @@ impl Bytestream for MediaSourceStream {
                 if self.pos >= self.end_pos {
                     self.fetch_buffer_or_eof()?;
                 }
-                unsafe { *quad_byte.get_unchecked_mut(i) = *self.buf.get_unchecked(self.pos) }
+                quad_byte[i] = self.buf[self.pos];
                 self.pos += 1;
             }
         }

--- a/sonata-core/src/sample.rs
+++ b/sonata-core/src/sample.rs
@@ -34,6 +34,7 @@ pub enum SampleFormat {
 /// underlying data type. Additionally, `Sample` provides information regarding the
 /// format of underlying data types representing the sample when in memory, but also
 /// when exported.
+pub trait Sample: Copy + Clone + Sized + Default {
 pub trait Sample : Copy + Clone + Sized {
 
     /// The `StreamType` is the primitive data type, or fixed-size byte array, that

--- a/sonata-core/src/sample.rs
+++ b/sonata-core/src/sample.rs
@@ -35,7 +35,6 @@ pub enum SampleFormat {
 /// format of underlying data types representing the sample when in memory, but also
 /// when exported.
 pub trait Sample: Copy + Clone + Sized + Default {
-pub trait Sample : Copy + Clone + Sized {
 
     /// The `StreamType` is the primitive data type, or fixed-size byte array, that
     /// represents the sample when exported.


### PR DESCRIPTION
The reason i would want to use a decoder library in rust is for safety. This library uses a lot of unsafe. I removed some that were trivial to fix (and partially instantly UB).
Others i can not simply remove because its too deeply interwoven with other code, but to me seem to be UB. I added FIXME annotations to those.
Lastly there is some that look like they are fine, but are lacking comments on why they are actually safe. I added TODO annotations to those.

The main use of unsafe was to skip bounds checking on indexing and initializing arrays. Initializing 2 bytes big arrays on the stack costs literally nothing. Indexing can sometimes be avoided by using iterator (added some TODO notes there, too). In other cases please describe why it is actually safe to use unchecked indexing when you have to (after benchmarking ofc). unsafe is not a go faster button and should be handled with a lot of care because it potentially breaks rusts core memory safety promises.

Introduced a dependency on [byteorder](https://docs.rs/byteorder/1.3.2/byteorder/) for endiannes-respecting reading of floats without unsafe casting. you might want to use that in more places, replacing some custom code.

[chunks](https://doc.rust-lang.org/std/primitive.slice.html#method.chunks) and [step_by](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.step_by) can be useful for strided iteration.

some of the manual buffer management might possibly be able to utilize [Cursor](https://doc.rust-lang.org/std/io/struct.Cursor.html), not 100% sure about that though.