### PR TITLE
Fix build on non-linux

### DIFF
--- a/sonata-play/src/main.rs
+++ b/sonata-play/src/main.rs
@@ -10,7 +10,7 @@ use std::fs::File;
 use std::path::Path;
 use clap::{Arg, App};
 use sonata;
-use sonata::core::errors::Result;
+use sonata::core::errors::{Result, unsupported_error};
 use sonata::core::audio::*;
 use sonata::core::codecs::DecoderOptions;
 use sonata::core::formats::{Cue, FormatReader, Hint, FormatOptions, ProbeDepth, ProbeResult, ColorMode, Visual, Stream};


### PR DESCRIPTION
```rust
#[cfg(not(target_os = "linux"))]
fn play(_: Box<dyn FormatReader>, _: &DecoderOptions) -> Result<()> {
    // TODO: Support the platform.
    unsupported_error("Playback is not supported on your platform.")
}
```
Did not compile.